### PR TITLE
feat: get refresh token

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "graphql": "^14.2.1",
     "graphql-tools": "^4.0.4",
     "jsonwebtoken": "^8.5.1",
+    "mamushi": "^1.1.5",
     "node-fetch": "^2.5.0",
     "typescript": "^3.4.5"
   },

--- a/src/@types/opn/index.d.ts
+++ b/src/@types/opn/index.d.ts
@@ -1,0 +1,3 @@
+declare module "opn" {
+  export default function opn(url: string);
+}

--- a/src/scripts/getRefreshToken.test.ts
+++ b/src/scripts/getRefreshToken.test.ts
@@ -1,0 +1,64 @@
+import test from "ava";
+import { openBrowser, getRefreshToken } from "./getRefreshToken";
+import { Response } from "node-fetch";
+
+test("opens a browser window", (t) => {
+  let nOpenBrowserCalls = 0;
+  const testUrl = "http://test.com/";
+
+  function mockOpenBrowser(url: string): void {
+    nOpenBrowserCalls += 1;
+    t.is(url, testUrl);
+  }
+  openBrowser(mockOpenBrowser, testUrl);
+
+  t.is(nOpenBrowserCalls, 1);
+});
+
+test("getRefreshToken", async (t) => {
+  let nOpenBrowserCalls = 0;
+  let nFetchCalls = 0;
+  let nGetInputCalls = 0;
+  const testUrl =
+    "https://accounts.google.com/o/oauth2/v2/auth?client_id=test_id&response_type=code&scope=openid%20email&access_type=offline&redirect_uri=urn:ietf:wg:oauth:2.0:oob";
+
+  const iapOptions = {
+    clientId: "test_id",
+    clientSecret: "test",
+    iapClientId: "not_used",
+  };
+
+  function mockOpenBrowser(url: string): void {
+    nOpenBrowserCalls += 1;
+    t.is(url, testUrl);
+  }
+
+  const mockFetch = (response: any) => async (): Promise<Response> => {
+    nFetchCalls += 1;
+    return new Response(JSON.stringify(response));
+  };
+
+  async function mockUserInput(): Promise<string> {
+    nGetInputCalls += 1;
+    return new Promise((resolve) => {
+      resolve("test_client_id");
+    });
+  }
+
+  const response = {
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    refresh_token: "some_refresh_token",
+  };
+
+  const refreshToken = await getRefreshToken(
+    mockOpenBrowser,
+    mockUserInput,
+    mockFetch(response),
+    iapOptions,
+  );
+
+  t.is(nOpenBrowserCalls, 1);
+  t.is(nFetchCalls, 1);
+  t.is(nGetInputCalls, 1);
+  t.is(refreshToken, "some_refresh_token");
+});

--- a/src/scripts/getRefreshToken.ts
+++ b/src/scripts/getRefreshToken.ts
@@ -1,0 +1,59 @@
+import fetch from "node-fetch";
+
+export function openBrowser(browser: (url: string) => void, url: string): void {
+  browser(url);
+}
+
+/*
+ * All of the options below are described in https://cloud.google.com/iap/docs/authentication-howto
+ * Please prepare a Other type client id and secret as described in the above link in "Authenticating from a desktop app" section
+ */
+interface DesktopIAPOptions {
+  // other type client id
+  clientId: string;
+  // other type client secret
+  clientSecret: string;
+  // global IAP client ID
+  iapClientId: string;
+}
+
+export async function getRefreshToken(
+  browser: (url: string) => void,
+  inputHandler: (question: string) => Promise<string>,
+  fetcher: Function = fetch,
+  options: DesktopIAPOptions,
+): Promise<string> {
+  const url = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${
+    options.clientId
+  }&response_type=code&scope=openid%20email&access_type=offline&redirect_uri=urn:ietf:wg:oauth:2.0:oob`;
+
+  openBrowser(browser, url);
+
+  // await input from user
+  const loginToken = await inputHandler(
+    "Please input the token you received in the browser",
+  );
+
+  const oauthTokenBaseUrl = "https://www.googleapis.com/oauth2/v4/token";
+
+  const body = {
+    code: loginToken,
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    client_id: options.clientId,
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    client_secret: options.clientSecret,
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    redirect_uri: "urn:ietf:wg:oauth:2.0:oob",
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    grant_type: "authorization_code",
+  };
+
+  const request = await fetcher(oauthTokenBaseUrl, {
+    body: JSON.stringify(body),
+    method: "POST",
+  });
+
+  const response = await request.json();
+
+  return String(response["refresh_token"]);
+}

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -1,0 +1,25 @@
+import { GetString } from "mamushi";
+import opn from "opn";
+import fetch from "node-fetch";
+import { getRefreshToken } from "./getRefreshToken";
+import { handleUserInput } from "./inputHandler";
+
+async function start(): Promise<void> {
+  const options = {
+    clientId: GetString("CLIENT_ID"),
+    clientSecret: GetString("CLIENT_SECRET"),
+    iapClientId: GetString("IAP_CLIENT_ID"),
+  };
+  const refreshToken = await getRefreshToken(
+    opn,
+    handleUserInput,
+    fetch,
+    options,
+  );
+
+  console.log(
+    `Your refresh token is: "${refreshToken}" please save it to your .env file`,
+  );
+}
+
+start();

--- a/src/scripts/inputHandler.ts
+++ b/src/scripts/inputHandler.ts
@@ -1,0 +1,15 @@
+import readline from "readline";
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+export function handleUserInput(question: string): Promise<string> {
+  return new Promise((resolve) => {
+    rl.question(`${question}: `, (answer) => {
+      rl.close();
+      resolve(answer);
+    });
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "sourceMap": true,
     "skipLibCheck": true,
     "baseUrl": ".",
+    "typeRoots": ["./node_modules/@types", "./src/@types"],
     "outDir": "dist",
     "strict": true
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2345,6 +2345,11 @@ make-error@^1.1.1:
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
   integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==
 
+mamushi@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/mamushi/-/mamushi-1.1.5.tgz#dcb84ac3deb715e27a8ed1790976748266e7831b"
+  integrity sha512-22ye6urdgnq5M1vodoeYMlfyEY5Mb+aGRLezhAo6WlJU+X321ohXAjWWoyzq+bZ9GZnYMA5nGxx/3GixET52zg==
+
 map-age-cleaner@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"


### PR DESCRIPTION
- readme coming in next PR
- adds mamushi dependency for getting env variables
- adds opn for opening browser
- adds types for opn (@types contains only a blank project)
- adjust tsconfig to allow for custom types
- uses in-built readline for getting user input
- allows for getting refresh_token from Google IAP