### PR TITLE
chore: replace opn with open

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "jsonwebtoken": "^8.5.1",
     "mamushi": "^1.1.5",
     "node-fetch": "^2.6.0",
-    "opn": "^6.0.0",
+    "open": "^6.4.0",
     "typescript": "^3.5.3"
   },
   "devDependencies": {

--- a/src/@types/opn/index.d.ts
+++ b/src/@types/opn/index.d.ts
@@ -1,3 +1,0 @@
-declare module "opn" {
-  export default function opn(url: string);
-}

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -1,5 +1,5 @@
 import { GetString } from "mamushi";
-import opn from "opn";
+import open from "open";
 import fetch from "node-fetch";
 import { getRefreshToken } from "./getRefreshToken";
 import { handleUserInput } from "./inputHandler";
@@ -11,7 +11,7 @@ async function start(): Promise<void> {
     iapClientId: GetString("IAP_CLIENT_ID"),
   };
   const refreshToken = await getRefreshToken(
-    opn,
+    open,
     handleUserInput,
     fetch,
     options,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2636,10 +2636,10 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
-opn@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/opn/-/opn-6.0.0.tgz#3c5b0db676d5f97da1233d1ed42d182bc5a27d2d"
-  integrity sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==
+open@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-6.4.0.tgz#5c13e96d0dc894686164f18965ecfe889ecfc8a9"
+  integrity sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==
   dependencies:
     is-wsl "^1.1.0"
 


### PR DESCRIPTION
- removes manual types as open has typescript types
- replaces dependencies