### PR TITLE
chore: fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ CLIENT_SECRET - Client secret of the desktop application created in IAP
 ```json
 {
   "scripts": {
-    "generate:token": "node ./node_modules/@kiwicom/js-iap-middleware/dist/scripts"
+    "generate:token": "node ./node_modules/@kiwicom/iam/dist/scripts"
   }
 }
 ```


### PR DESCRIPTION
- readme had instructions pointing to a non-existent package