### PR TITLE
Scripts: add generate-iap-token command to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "0.2.0",
   "name": "@kiwicom/iam",
   "repository": "kiwicom/js-iam-middleware",
+  "bin": {
+    "generate-iap-token": "./dist/scripts/index.js"
+  },
   "files": [
     "dist"
   ],

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -1,3 +1,5 @@
+#!/bin/env node
+
 import { GetString } from "mamushi";
 import open from "open";
 import fetch from "node-fetch";


### PR DESCRIPTION
This change allows to run the script using `generate-iap-token` instead of  `node ./node_modules/@kiwicom/iam/dist/scripts` after the package is installed.

Closes #28 