### PR TITLE
fix: add graphql file to the published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "generate-iap-token": "./dist/scripts/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "AuthorizationDirective.graphql"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
We had `AuthorizationDirective.graphql` inside the published package before, but then we added the `files` attribute to package.json and forgot to include it. 

So now projects using the graphql directive can't upgrade the package as this file is missing.