### PR TITLE
feat: use audience instead of two init values

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,8 @@ example below.
 import { authenticationMiddleware } from "@kiwicom/iam";
 
 const options = {
-  // These two fields are mandatory and are used to check what service
-  // is the token intended for (audience).
-  iapProjectNumber: process.env.IAP_PROJECT_NUMBER,
-  iapServiceID: process.env.IAP_SERVICE_ID,
+  // The correct audience for your project can be found in GCP.
+  audience: process.env.IAP_AUDIENCE,
 };
 
 const app = express();

--- a/src/authenticationMiddleware.test.ts
+++ b/src/authenticationMiddleware.test.ts
@@ -1,5 +1,11 @@
 import test from "ava";
-import { required } from "./authenticationMiddleware";
+import { audienceRegex, authenticationMiddleware, required } from "./authenticationMiddleware";
+
+const asyncForEach = async (array: string[], callback: Function): Promise<any> => {
+  for (let index = 0; index < array.length; index++) {
+    await callback(array[index], index, array);
+  }
+};
 
 test("required returns correct values", (t) => {
   const tests: Array<[any, string]> = [
@@ -23,4 +29,45 @@ test("required throws on null or undefined", (t) => {
 
   const err2 = t.throws(() => required(null, "notExisting"));
   t.is(err2.message, "Missing 'notExisting', option must be specified.");
+});
+
+test("authenticationMiddleware throws on getting IAP token if initialised with audience", async t => {
+  const tests: string[] = [
+    "/projects/000000000000/global/backendServices/0000000000000000000",
+    "/projects/000000000000/apps/my-sample-project-191923",
+  ];
+
+  await asyncForEach(tests, async (audience: string) => {
+    const opts = {
+      audience: audience
+    };
+
+    await t.throwsAsync(
+      () => authenticationMiddleware(opts)({} as any, {} as any, {} as any),
+      {instanceOf: TypeError, message: "req.get is not a function"}
+    );
+  })
+});
+
+test("authenticationMiddleware throws on malformed audience", async t => {
+  const opts = {
+    audience: "this is not valid"
+  };
+
+  await t.throwsAsync(
+    () => authenticationMiddleware(opts)({} as any, {} as any, {} as any),
+    {instanceOf: TypeError, message: `'audience' needs to be a string matching ${audienceRegex}`}
+  );
+});
+
+test("authenticationMiddleware throws on getting IAP token if initialised with deprecated options", async t => {
+  const opts = {
+    iapProjectNumber: "test",
+    iapServiceID: "test",
+  };
+
+  await t.throwsAsync(
+    () => authenticationMiddleware(opts)({} as any, {} as any, {} as any),
+    {instanceOf: TypeError, message: "req.get is not a function"}
+  );
 });

--- a/src/authenticationMiddleware.test.ts
+++ b/src/authenticationMiddleware.test.ts
@@ -1,11 +1,5 @@
 import test from "ava";
-import { audienceRegex, authenticationMiddleware, required } from "./authenticationMiddleware";
-
-const asyncForEach = async (array: string[], callback: Function): Promise<any> => {
-  for (let index = 0; index < array.length; index++) {
-    await callback(array[index], index, array);
-  }
-};
+import { audienceRegex, authenticationMiddleware, required, validateAudience } from "./authenticationMiddleware";
 
 test("required returns correct values", (t) => {
   const tests: Array<[any, string]> = [
@@ -23,6 +17,29 @@ test("required returns correct values", (t) => {
   });
 });
 
+test("validateAudience passes on valid values", (t) => {
+  const tests: string[] = [
+    "/projects/000000000000/global/backendServices/0000000000000000000",
+    "/projects/000000000000/apps/my-sample-project-191923",
+  ];
+  tests.forEach(audience => {
+    t.notThrows(() => validateAudience(audience));
+  });
+});
+
+test("validateAudience throws on invalid values", (t) => {
+  const tests: any[] = [
+    "not a valid audience",
+    "",
+    undefined,
+    {},
+  ];
+  tests.forEach(audience => {
+    const err = t.throws(() => validateAudience(audience));
+    t.is(err.message, `'audience' needs to be a string matching ${audienceRegex}`);
+  });
+});
+
 test("required throws on null or undefined", (t) => {
   const err = t.throws(() => required(undefined, "notExisting"));
   t.is(err.message, "Missing 'notExisting', option must be specified.");
@@ -37,7 +54,7 @@ test("authenticationMiddleware throws on getting IAP token if initialised with a
     "/projects/000000000000/apps/my-sample-project-191923",
   ];
 
-  await asyncForEach(tests, async (audience: string) => {
+  for (let audience of tests) {
     const opts = {
       audience: audience
     };
@@ -46,12 +63,12 @@ test("authenticationMiddleware throws on getting IAP token if initialised with a
       () => authenticationMiddleware(opts)({} as any, {} as any, {} as any),
       {instanceOf: TypeError, message: "req.get is not a function"}
     );
-  })
+  }
 });
 
 test("authenticationMiddleware throws on malformed audience", async t => {
   const opts = {
-    audience: "this is not valid"
+    audience: "not a valid audience"
   };
 
   await t.throwsAsync(

--- a/src/authenticationMiddleware.ts
+++ b/src/authenticationMiddleware.ts
@@ -14,8 +14,13 @@ export function required<T>(value: T | undefined | null, fieldName: string): T {
     throw Error(`Missing '${fieldName}', option must be specified.`);
   }
 
-  console.log(`'${fieldName}' is deprecated and will be removed. Use 'audience' instead.`);
   return value;
+}
+
+export function validateAudience(audience: string | undefined): void {
+  if (!(typeof audience === 'string' && audience.match(audienceRegex))) {
+    throw TypeError(`'audience' needs to be a string matching ${audienceRegex}`);
+  }
 }
 
 export const authenticationMiddleware = (opts: Options) => async (
@@ -23,13 +28,15 @@ export const authenticationMiddleware = (opts: Options) => async (
   res: Response,
   next: NextFunction,
 ) => {
-  if (opts.audience) {
-    if (!(typeof opts.audience === 'string' && opts.audience.match(audienceRegex))) {
-      throw TypeError(`'audience' needs to be a string matching ${audienceRegex}`);
-    }
-  } else {
+  // Handle deprecated options
+  if (opts.iapProjectNumber && opts.iapServiceID) {
     required(opts.iapProjectNumber, "iapProjectNumber");
     required(opts.iapServiceID, "iapServiceID");
+
+    console.log("'iapProjectNumber' and 'iapServiceID' are deprecated and will be removed. Use 'audience' instead.");
+  }
+  else {
+    validateAudience(required(opts.audience, "audience"));
   }
 
   const expectedAudience = opts.audience || `/projects/${opts.iapProjectNumber}/global/backendServices/${opts.iapServiceID}`;

--- a/src/authenticationMiddleware.ts
+++ b/src/authenticationMiddleware.ts
@@ -1,7 +1,10 @@
 import { Request, Response, NextFunction } from "express";
 import { validateIAPToken } from "./validateIAPToken";
 
+export const audienceRegex = /^\/projects\/\d+\/(?:apps|global\/backendServices)\/(?:\d+|[a-z0-9-]+)$/;
+
 interface Options {
+  audience?: string;
   iapProjectNumber?: string;
   iapServiceID?: string;
 }
@@ -10,6 +13,8 @@ export function required<T>(value: T | undefined | null, fieldName: string): T {
   if (value === undefined || value === null) {
     throw Error(`Missing '${fieldName}', option must be specified.`);
   }
+
+  console.log(`'${fieldName}' is deprecated and will be removed. Use 'audience' instead.`);
   return value;
 }
 
@@ -18,11 +23,17 @@ export const authenticationMiddleware = (opts: Options) => async (
   res: Response,
   next: NextFunction,
 ) => {
-  required(opts.iapProjectNumber, "iapProjectNumber");
-  required(opts.iapServiceID, "iapServiceID");
+  if (opts.audience) {
+    if (!(typeof opts.audience === 'string' && opts.audience.match(audienceRegex))) {
+      throw TypeError(`'audience' needs to be a string matching ${audienceRegex}`);
+    }
+  } else {
+    required(opts.iapProjectNumber, "iapProjectNumber");
+    required(opts.iapServiceID, "iapServiceID");
+  }
 
+  const expectedAudience = opts.audience || `/projects/${opts.iapProjectNumber}/global/backendServices/${opts.iapServiceID}`;
   const iapToken = req.get("x-goog-iap-jwt-assertion");
-  const expectedAudience = `/projects/${opts.iapProjectNumber}/global/backendServices/${opts.iapServiceID}`;
 
   try {
     if (!iapToken) {

--- a/src/getUser.test.ts
+++ b/src/getUser.test.ts
@@ -19,6 +19,7 @@ test("getUser caches results", async (t) => {
     location: "",
     isVendor: false,
     teamMembership: [],
+    orgStructure: "",
     manager: "",
     permissions: [],
   };

--- a/src/userCache.ts
+++ b/src/userCache.ts
@@ -9,6 +9,7 @@ export interface User {
   location: string;
   isVendor: boolean;
   teamMembership: string[];
+  orgStructure: string;
   manager: string;
   permissions: string[];
 }


### PR DESCRIPTION
To keep consistency with other middlewares. The audience can be simply copied from GCP, parsing out the ids is actually more work for devs than to use the audience directly.